### PR TITLE
Select the correct CCM nodelist file

### DIFF
--- a/scripts/fabtests/ccm_runfabtests.sh
+++ b/scripts/fabtests/ccm_runfabtests.sh
@@ -99,8 +99,7 @@ cat >> ${ccm_login_script} <<"END_OF_CCMLOGIN_SCRIPT_2"
 node_1=""
 node_2=""
 
-ccm_login_node_dir="${HOME}/.crayccm/"
-ccm_nodelist_file="${ccm_login_node_dir}/`ls ${ccm_login_node_dir}`"
+ccm_nodelist_file=$1
 node_index=0
 
 if [[ ${debug} -ne 0 ]]
@@ -197,12 +196,23 @@ END_OF_CCMLOGIN_SCRIPT_2
 
 chmod 755 ${ccm_login_script}
 
-if [[ ${debug} -ne 0 ]]
-then
-    echo "*** cmd: '${ccm_login} ${ccm_login_script}'"
+ccm_login_node_dir="${HOME}/.crayccm/"
+if [ "$PBS_JOBID" != "" ]; then
+    ccm_nodelist_file="${ccm_login_node_dir}/ccm_nodelist.$PBS_JOBID"
+elif [ "$SLURM_JOB_ID" != "" ]; then
+    ccm_nodelist_file="${ccm_login_node_dir}/ccm_nodelist.$SLURM_JOB_ID"
+elif [ "$SLURM_JOBID" != "" ]; then
+    ccm_nodelist_file="${ccm_login_node_dir}/ccm_nodelist.$SLURM_JOBID"
+else
+    ccm_nodelist_file="${ccm_login_node_dir}/`ls ${ccm_login_node_dir}`"    
 fi
 
-${ccm_login} ${ccm_login_script}
+if [[ ${debug} -ne 0 ]]
+then
+    echo "*** cmd: '${ccm_login} ${ccm_login_script} ${ccm_nodelist_file}'"
+fi
+
+${ccm_login} ${ccm_login_script} ${ccm_nodelist_file}
 
 if [[ ${debug} -eq 0 ]]
 then


### PR DESCRIPTION
The nodelist filename is determined via the PBS or SLURM jobid, and
there can be more than one in the .crayccm directory if you're running
more than one CCM job at a time.  This commit tries to select the
correct CCM nodelist file via PBS and SLURM environment variables, and
if that fails, falls back to the old method.

Note that I made the nodlist file an argument to the ccmlogin script
because once in ccmlogin under PBS the jobid changes.

@tonyzinger 
